### PR TITLE
remove further references to FF-Darmstadt

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Firmware - Freifunk Darmstadt</title>
+    <title>Firmware - Freifunk Karlsruhe</title>
     <link href="vendor/bootstrap-3.3.6/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="app.css" />
   </head>
@@ -28,7 +28,7 @@
         <div class="tab-pane step-type">
           <hr>
           <p>
-            Bitte verwende das <em>Erstinstallationsimage</em>, wenn Du deinen Router gerade erst gekauft hast und sich darauf noch keine Freifunk-/OpenWRT-Firmware befindet. Ist bereits eine Freifunk- oder OpenWRT-Firmware installiert, verwende bitte die mit <em>Upgrade</em> bezeichnete Version. Weitere Informationen zum Firmware-Upgrade findest Du in unserem <a href="https://wiki.darmstadt.freifunk.net/Firmware_Update">Wiki</a>.
+            Bitte verwende das <em>Erstinstallationsimage</em>, wenn Du deinen Router gerade erst gekauft hast und sich darauf noch keine Freifunk-/OpenWRT-Firmware befindet. Ist bereits eine Freifunk- oder OpenWRT-Firmware installiert, verwende bitte die mit <em>Upgrade</em> bezeichnete Version.
           </p>
           <div class="radiogroup typeselect"></div>
         </div>


### PR DESCRIPTION
I could not find a good ffka wiki site explaining the firmware flashing or upgrade in detail (as the ff darmstadt wiki does).
As the darmstadt wiki has php problems, I removed the link.